### PR TITLE
Need CoreLocation framework to pass build

### DIFF
--- a/Specs/InMobiSDK/4.5.1/InMobiSDK.podspec.json
+++ b/Specs/InMobiSDK/4.5.1/InMobiSDK.podspec.json
@@ -25,6 +25,7 @@
     "AudioToolbox",
     "AVFoundation",
     "CoreTelephony",
+    "CoreLocation",
     "EventKit",
     "EventKitUI",
     "MessageUI",


### PR DESCRIPTION
If without CoreLocation framework, the error message as below
Undefined symbols for architecture : "_OBJC_CLASS_$_CLLocationManager"
...
objc-class-ref in libInMobi.a(IMGeoLocationManager.o) ...
